### PR TITLE
Fix wrong stripe_id column in webhook

### DIFF
--- a/classes/WebhookController.php
+++ b/classes/WebhookController.php
@@ -32,4 +32,17 @@ class WebhookController extends CashierWebhookController
     {
         return new Response;
     }
+
+    /**
+     * Get the billable entity instance by Stripe ID.
+     *
+     * @param  string  $stripeId
+     * @return \Laravel\Cashier\Billable
+     */
+    protected function getUserByStripeId($stripeId)
+    {
+        $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model');
+
+        return (new $model)->where('offline_cashier_stripe_id', $stripeId)->first();
+    }
 }


### PR DESCRIPTION
The webhook for when a user is unsubscribed gives a 500 error with the following message in the logs:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'stripe_id' in 'where clause' (SQL: select * from `users` where `stripe_id` = cus_CvTnQ6zzi2SXND and `users`.`deleted_at` is null limit 1)
```

Overriding the Stripe method that asks for `stripe_id` instead of `offline_cashier_stripe_id` fixes the problem.